### PR TITLE
Fix OperationErrors type definition

### DIFF
--- a/packages/zenko/src/__tests__/__snapshots__/zenko.test.ts.snap
+++ b/packages/zenko/src/__tests__/__snapshots__/zenko.test.ts.snap
@@ -84,10 +84,10 @@ type PathFn<TArgs extends unknown[] = []> = (...args: TArgs) => string;
 type RequestMethod = "get" | "put" | "post" | "delete" | "options" | "head" | "patch" | "trace";
 type HeaderFn<TArgs extends unknown[] = [], TResult = Record<string, unknown> | Record<string, never>> = (...args: TArgs) => TResult;
 type OperationErrors<TClient = unknown, TServer = unknown, TDefault = unknown, TOther = unknown> = {
-  clientErrors?: Record<string, TClient>;
-  serverErrors?: Record<string, TServer>;
-  defaultErrors?: Record<string, TDefault>;
-  otherErrors?: Record<string, TOther>;
+  clientErrors?: TClient;
+  serverErrors?: TServer;
+  defaultErrors?: TDefault;
+  otherErrors?: TOther;
 };
 type OperationDefinition<TMethod extends RequestMethod, TPath extends (...args: any[]) => string, TRequest = undefined, TResponse = undefined, THeaders extends HeaderFn | undefined = undefined, TErrors extends OperationErrors | undefined = undefined> = {
   method: TMethod;

--- a/packages/zenko/src/types.ts
+++ b/packages/zenko/src/types.ts
@@ -21,10 +21,10 @@ export type OperationErrors<
   TDefault = unknown,
   TOther = unknown,
 > = {
-  clientErrors?: Record<string, TClient>
-  serverErrors?: Record<string, TServer>
-  defaultErrors?: Record<string, TDefault>
-  otherErrors?: Record<string, TOther>
+  clientErrors?: TClient
+  serverErrors?: TServer
+  defaultErrors?: TDefault
+  otherErrors?: TOther
 }
 
 export type OperationDefinition<

--- a/packages/zenko/src/zenko.ts
+++ b/packages/zenko/src/zenko.ts
@@ -504,10 +504,10 @@ function appendHelperTypesImport(
       buffer.push(
         "type OperationErrors<TClient = unknown, TServer = unknown, TDefault = unknown, TOther = unknown> = {"
       )
-      buffer.push("  clientErrors?: Record<string, TClient>;")
-      buffer.push("  serverErrors?: Record<string, TServer>;")
-      buffer.push("  defaultErrors?: Record<string, TDefault>;")
-      buffer.push("  otherErrors?: Record<string, TOther>;")
+      buffer.push("  clientErrors?: TClient;")
+      buffer.push("  serverErrors?: TServer;")
+      buffer.push("  defaultErrors?: TDefault;")
+      buffer.push("  otherErrors?: TOther;")
       buffer.push("};")
       buffer.push(
         "type OperationDefinition<TMethod extends RequestMethod, TPath extends (...args: any[]) => string, TRequest = undefined, TResponse = undefined, THeaders extends HeaderFn | undefined = undefined, TErrors extends OperationErrors | undefined = undefined> = {"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified error representation across the SDK: error categories now use direct values instead of string-keyed maps, resulting in a cleaner, more consistent error structure.
  - The shape of error objects returned and consumed by the SDK has changed; existing integrations that rely on mapped error objects may require updates to handle the new structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->