### PR TITLE
Include empty responses within OperationErrors

### DIFF
--- a/packages/zenko/src/__tests__/__snapshots__/inline-response-array.test.ts.snap
+++ b/packages/zenko/src/__tests__/__snapshots__/inline-response-array.test.ts.snap
@@ -24,6 +24,17 @@ export const bySource = {
   method: "get",
   path: paths.bySource,
   response: BySourceResponse200,
+  errors: {
+    clientErrors: {
+      badRequest: undefined,
+      forbidden: undefined,
+      notFound: undefined,
+    },
+    serverErrors: {
+      internalServerError: undefined,
+      serviceUnavailable: undefined,
+    },
+  },
 } as const;
 
 // Operation Types
@@ -33,7 +44,7 @@ export type BySourceOperation = OperationDefinition<
   undefined,
   typeof BySourceResponse200,
   undefined,
-  OperationErrors
+  OperationErrors<{ badRequest: undefined; forbidden: undefined; notFound: undefined }, { internalServerError: undefined; serviceUnavailable: undefined }, unknown, unknown>
 >;
 "
 `;

--- a/packages/zenko/src/__tests__/__snapshots__/no-response-content.test.ts.snap
+++ b/packages/zenko/src/__tests__/__snapshots__/no-response-content.test.ts.snap
@@ -24,6 +24,17 @@ export const PutSomething = {
   method: "put",
   path: paths.PutSomething,
   response: undefined,
+  errors: {
+    clientErrors: {
+      badRequest: undefined,
+      forbidden: undefined,
+      notFound: undefined,
+    },
+    serverErrors: {
+      internalServerError: undefined,
+      serviceUnavailable: undefined,
+    },
+  },
 } as const;
 
 // Operation Types
@@ -33,7 +44,7 @@ export type PutSomethingOperation = OperationDefinition<
   undefined,
   undefined,
   undefined,
-  OperationErrors
+  OperationErrors<{ badRequest: undefined; forbidden: undefined; notFound: undefined }, { internalServerError: undefined; serviceUnavailable: undefined }, unknown, unknown>
 >;
 "
 `;

--- a/packages/zenko/src/zenko.ts
+++ b/packages/zenko/src/zenko.ts
@@ -763,6 +763,12 @@ function getResponseTypes(
       // No content - handle based on status code
       if (statusCode === "204" || /^3\d\d$/.test(statusCode)) {
         successCodes.set(statusCode, "undefined")
+      } else if (isErrorStatus(statusCode)) {
+        // Include error responses even without content
+        errorEntries.push({
+          code: statusCode,
+          schema: "undefined",
+        })
       }
       continue
     }

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,8 @@
   "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "inputs": ["**/*.{ts,tsx}"]
     },
     "//#lint": {},
     "//#lint:check": {},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * No-content HTTP error responses are now correctly detected and surfaced instead of being ignored, improving error reporting and reliability.
* **Chores**
  * Updated build configuration to better track source inputs for incremental builds, improving build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->