### PR TITLE
Include Bun security scanner step to the build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           files: ./packages/zenko/coverage/lcov.info
+
+      - name: Run security scan
+        run: bun audit --audit-level=moderate
+        if: matrix.node-version == 24

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "zenko",
       "devDependencies": {
         "@prettier/plugin-oxc": "0.0.4",
+        "@socketsecurity/bun-security-scanner": "1.1.0",
         "oxlint": "1.11.2",
         "prettier": "3.6.2",
         "turbo": "2.5.8",
@@ -13,7 +14,7 @@
     },
     "packages/zenko": {
       "name": "zenko",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "bin": {
         "zenko": "dist/cli.cjs",
       },
@@ -210,6 +211,8 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.52.4", "", { "os": "win32", "cpu": "x64" }, "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.52.4", "", { "os": "win32", "cpu": "x64" }, "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w=="],
+
+    "@socketsecurity/bun-security-scanner": ["@socketsecurity/bun-security-scanner@1.1.0", "", {}, "sha512-kbZubfWPJzjohHBJjbT/vNRWh8y2hPnHjU3Qv5jxjZN0UvwetsJrfivixRwVZ+kZvIskkijXZTcyk0duYw/8WQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,8 @@
 [install]
 exact = true
 
+[install.security]
+provider = "@socketsecurity/bun-security-scanner"
+
 [test]
 preload = ["./.test-guard.ts"]

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@prettier/plugin-oxc": "0.0.4",
+    "@socketsecurity/bun-security-scanner": "1.1.0",
     "oxlint": "1.11.2",
     "prettier": "3.6.2",
     "turbo": "2.5.8",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a CI step to run a security scan at moderate severity, executed for Node 24 and placed after coverage upload in the test workflow.
  * Introduced configuration to enable a security scanner provider in installation settings.
  * Added a development dependency to support the security scanning integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->