### PR TITLE
Update tsdown config for treaty types

### DIFF
--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -10,13 +10,12 @@
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "./dist",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "paths": {
       "zenko": ["../zenko/index.ts"],
-      "zenko/treaty": ["../zenko/src/treaty.ts"],
+      // "zenko/treaty": ["../zenko/src/treaty.ts"],
       "~/*": ["./src/*"]
     }
   },

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -15,7 +15,6 @@
     "sourceMap": true,
     "paths": {
       "zenko": ["../zenko/index.ts"],
-      // "zenko/treaty": ["../zenko/src/treaty.ts"],
       "~/*": ["./src/*"]
     }
   },

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -15,6 +15,7 @@
     "sourceMap": true,
     "paths": {
       "zenko": ["../zenko/index.ts"],
+      "zenko/treaty": ["../zenko/src/treaty.ts"],
       "~/*": ["./src/*"]
     }
   },

--- a/packages/zenko/package.json
+++ b/packages/zenko/package.json
@@ -29,28 +29,38 @@
     "README.md",
     "dist/**/*.cjs",
     "dist/**/*.d.cts",
+    "dist/**/*.d.mts",
     "dist/**/*.d.ts",
     "dist/**/*.mjs"
   ],
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.cts"
+      },
       "bun": "./dist/index.mjs",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./types": {
-      "types": "./dist/types.d.ts",
+      "types": {
+        "import": "./dist/types.d.mts",
+        "require": "./dist/types.d.cts"
+      },
       "bun": "./dist/types.mjs",
       "import": "./dist/types.mjs",
       "require": "./dist/types.cjs"
     },
     "./treaty": {
-      "types": "./dist/treaty.d.ts",
+      "types": {
+        "import": "./dist/treaty.d.mts",
+        "require": "./dist/treaty.d.cts"
+      },
       "bun": "./dist/treaty.mjs",
       "import": "./dist/treaty.mjs",
       "require": "./dist/treaty.cjs"

--- a/packages/zenko/package.json
+++ b/packages/zenko/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zenko",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "description": "Generate TypeScript types and path functions from OpenAPI specs",
   "keywords": [
     "api",

--- a/packages/zenko/tsdown.config.ts
+++ b/packages/zenko/tsdown.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   entry: {
     index: "index.ts",
     cli: "src/cli.ts",
+    types: "src/types.ts",
     treaty: "src/treaty.ts",
   },
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.3.0-beta.2.
  * Improved TypeScript type distribution and conditional exports for better ESM/CommonJS compatibility.
  * Extended the build to produce and publish additional type artifacts so types are resolved correctly for both import and require consumers.
  * Cleaned up local TypeScript configuration for example builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->