### PR TITLE
Support for v2 schemas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,9 +18,9 @@
       "dependencies": {
         "@effect/platform": "0.96.1",
         "@effect/platform-node": "0.106.0",
-        "axios": "1.17.0",
+        "axios": "1.18.1",
         "effect": "3.21.2",
-        "undici": "7.24.6",
+        "undici": "8.7.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -46,7 +46,7 @@
     },
     "packages/zenko": {
       "name": "zenko",
-      "version": "0.3.0-beta.3",
+      "version": "0.3.0-beta.4",
       "bin": {
         "zenko": "dist/cli.cjs",
       },
@@ -68,7 +68,7 @@
   "packages": {
     "@babel/generator": ["@babel/generator@8.0.0-rc.3", "", { "dependencies": { "@babel/parser": "^8.0.0-rc.3", "@babel/types": "^8.0.0-rc.3", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA=="],
 
-    "@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.6", "", {}, "sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g=="],
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.3", "", {}, "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw=="],
 
@@ -90,7 +90,7 @@
 
     "@effect/sql": ["@effect/sql@0.51.1", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.1", "effect": "^3.21.2" } }, "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA=="],
 
-    "@effect/workflow": ["@effect/workflow@0.18.1", "", { "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.1", "@effect/rpc": "^0.75.1", "effect": "^3.21.2" } }, "sha512-FxsUxkyvd7CyN7tw4bQgmAJv8tf8hUwy72bwGYzKGpeuiEObiUKgO1pg8xM49gB6EtwOdVRJhytwcFc8eM/6ow=="],
+    "@effect/workflow": ["@effect/workflow@0.18.2", "", { "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.1", "@effect/rpc": "^0.75.1", "effect": "^3.21.2" } }, "sha512-2av0TexhxHnapQa3eLn6TkniokUFRZKf8dlWlLqbODMpXAJ3mm+DOHWM0ozMGkg9K/+zGCtiL3dMqJyJ8r7G8g=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -118,7 +118,7 @@
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
 
@@ -286,7 +286,7 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-Y7SJppD0Z8wjO3Ec0ZGd9KQ4Yv0BMnA8CIowj5Vp+OEVsosXDG2weK6/t1RRLfJmc2Ozrnd6y4DOgQys+mn3WQ=="],
 
-    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
@@ -294,7 +294,7 @@
 
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
 
-    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "@zenko/examples": ["@zenko/examples@workspace:packages/examples"],
 
@@ -304,11 +304,11 @@
 
     "ansis": ["ansis@4.3.1", "", {}, "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA=="],
 
-    "ast-kit": ["ast-kit@3.0.0-beta.1", "", { "dependencies": { "@babel/parser": "^8.0.0-beta.4", "estree-walker": "^3.0.3", "pathe": "^2.0.3" } }, "sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw=="],
+    "ast-kit": ["ast-kit@3.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "estree-walker": "^3.0.3", "pathe": "^2.0.3" } }, "sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
-    "axios": ["axios@1.17.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw=="],
+    "axios": ["axios@1.18.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g=="],
 
     "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
 
@@ -322,7 +322,7 @@
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
@@ -356,7 +356,7 @@
 
     "follow-redirects": ["follow-redirects@1.16.0", "", { "peerDependencies": { "debug": "*" }, "optionalPeers": ["debug"] }, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
-    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -398,17 +398,17 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "msgpackr": ["msgpackr@1.11.12", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg=="],
+    "msgpackr": ["msgpackr@1.12.1", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
 
-    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
-    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
     "oxfmt": ["oxfmt@0.42.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.42.0", "@oxfmt/binding-android-arm64": "0.42.0", "@oxfmt/binding-darwin-arm64": "0.42.0", "@oxfmt/binding-darwin-x64": "0.42.0", "@oxfmt/binding-freebsd-x64": "0.42.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.42.0", "@oxfmt/binding-linux-arm-musleabihf": "0.42.0", "@oxfmt/binding-linux-arm64-gnu": "0.42.0", "@oxfmt/binding-linux-arm64-musl": "0.42.0", "@oxfmt/binding-linux-ppc64-gnu": "0.42.0", "@oxfmt/binding-linux-riscv64-gnu": "0.42.0", "@oxfmt/binding-linux-riscv64-musl": "0.42.0", "@oxfmt/binding-linux-s390x-gnu": "0.42.0", "@oxfmt/binding-linux-x64-gnu": "0.42.0", "@oxfmt/binding-linux-x64-musl": "0.42.0", "@oxfmt/binding-openharmony-arm64": "0.42.0", "@oxfmt/binding-win32-arm64-msvc": "0.42.0", "@oxfmt/binding-win32-ia32-msvc": "0.42.0", "@oxfmt/binding-win32-x64-msvc": "0.42.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-QhejGErLSMReNuZ6vxgFHDyGoPbjTRNi6uGHjy0cvIjOQFqD6xmr/T+3L41ixR3NIgzcNiJ6ylQKpvShTgDfqg=="],
 
@@ -418,7 +418,7 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
@@ -432,7 +432,7 @@
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.23.2", "", { "dependencies": { "@babel/generator": "8.0.0-rc.3", "@babel/helper-validator-identifier": "8.0.0-rc.3", "@babel/parser": "8.0.0-rc.3", "@babel/types": "8.0.0-rc.3", "ast-kit": "^3.0.0-beta.1", "birpc": "^4.0.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.7", "obug": "^2.1.1", "picomatch": "^4.0.4" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20260325.1", "rolldown": "^1.0.0-rc.12", "typescript": "^5.0.0 || ^6.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ=="],
 
-    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
@@ -452,21 +452,27 @@
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
-    "undici": ["undici@7.24.6", "", {}, "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA=="],
+    "undici": ["undici@8.7.0", "", {}, "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ=="],
 
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unrun": ["unrun@0.2.39", "", { "dependencies": { "rolldown": "1.0.0-rc.17" }, "peerDependencies": { "synckit": "^0.11.11" }, "optionalPeers": ["synckit"], "bin": { "unrun": "dist/cli.mjs" } }, "sha512-h9FxYVpztY/wwq+bauLOh6Y3CWu2IVeRLq5lxzneBiIU9Tn86OGp9xiQrGhnYspAmg5dzdY0Cc8+Y70kuTARCg=="],
 
     "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
-    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
     "zenko": ["zenko@workspace:packages/zenko"],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "@effect/platform-node/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "ast-kit/@babel/parser": ["@babel/parser@8.0.4", "", { "dependencies": { "@babel/types": "^8.0.4" }, "bin": "./bin/babel-parser.js" }, "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g=="],
+
     "unrun/rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
+
+    "ast-kit/@babel/parser/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
     "unrun/rolldown/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 
@@ -501,5 +507,7 @@
     "unrun/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "x64" }, "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg=="],
 
     "unrun/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
+
+    "ast-kit/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
   }
 }

--- a/packages/examples/generate.js
+++ b/packages/examples/generate.js
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, mkdirSync } from "fs"
 import { dirname, relative, resolve } from "path"
 import {
   authApiYamlPath,
+  blockscoutYamlPath,
   enumDemoYamlPath,
   nullableAllOfErrorsYamlPath,
   petstoreYamlPath,
@@ -13,6 +14,7 @@ import { generate, generateTreatyModule } from "zenko"
 
 const specInputPaths = {
   "auth-api.yaml": authApiYamlPath,
+  "blockscout.yaml": blockscoutYamlPath,
   "enum-demo.yaml": enumDemoYamlPath,
   "nullable-allof-errors.yaml": nullableAllOfErrorsYamlPath,
   "petstore.yaml": petstoreYamlPath,
@@ -141,6 +143,10 @@ async function generateTreatyModuleForGen(genFileName, treatyFileName, label) {
       "nullable-allof-errors.yaml",
       "nullable-allof-errors.gen.ts"
     )
+    const blockscoutSuccess = generateSchema(
+      "blockscout.yaml",
+      "blockscout.gen.ts"
+    )
     if (
       !petstoreSuccess ||
       !trainTravelSuccess ||
@@ -148,7 +154,8 @@ async function generateTreatyModuleForGen(genFileName, treatyFileName, label) {
       !tictactoeSuccess ||
       !enumDemoSuccess ||
       !fireblocksSuccess ||
-      !nullableAllOfErrorsSuccess
+      !nullableAllOfErrorsSuccess ||
+      !blockscoutSuccess
     ) {
       process.exit(1)
     }

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -13,9 +13,9 @@
   "dependencies": {
     "@effect/platform": "0.96.1",
     "@effect/platform-node": "0.106.0",
-    "axios": "1.17.0",
+    "axios": "1.18.1",
     "effect": "3.21.2",
-    "undici": "7.24.6",
+    "undici": "8.7.0",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/packages/specs/index.ts
+++ b/packages/specs/index.ts
@@ -8,6 +8,7 @@ export const additionalPropertiesYamlPath = resourcePath(
 )
 export const anyOfCombinationsYamlPath = resourcePath("anyof-combinations.yaml")
 export const authApiYamlPath = resourcePath("auth-api.yaml")
+export const blockscoutYamlPath = resourcePath("blockscout.yaml")
 export const complexCompositionYamlPath = resourcePath(
   "complex-composition.yaml"
 )

--- a/packages/specs/resources/blockscout.yaml
+++ b/packages/specs/resources/blockscout.yaml
@@ -1,0 +1,560 @@
+swagger: "2.0"
+info:
+  title: Stats service
+  version: version not set
+  contact:
+    name: Blockscout
+    url: https://blockscout.com
+    email: support@blockscout.com
+tags:
+  - name: StatsService
+  - name: Health
+schemes:
+  - https
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /api/v1/charts/batch-update:
+    post:
+      summary: |-
+        Triggers a batch update of the specified charts (or all charts).
+        Requires API key authentication.
+      operationId: StatsService_BatchUpdateCharts
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/v1BatchUpdateChartsResult"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/v1BatchUpdateChartsRequest"
+      tags:
+        - Instances
+      security:
+        - ApiKeyAuth: []
+  /api/v1/counters:
+    get:
+      summary: Returns all available counter stats for the stats page.
+      operationId: StatsService_GetCounters
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/v1Counters"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - StatsService
+  /api/v1/lines:
+    get:
+      summary: |-
+        Returns metadata (title, description, available resolutions) for all
+        line charts, organized into sections.
+      operationId: StatsService_GetLineCharts
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/v1LineCharts"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - StatsService
+  /api/v1/lines/{name}:
+    get:
+      summary: |-
+        Returns data points for a specific line chart, with optional date range
+        and resolution filtering.
+      operationId: StatsService_GetLineChart
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/v1LineChart"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      parameters:
+        - name: name
+          description: Identifier of the chart to retrieve (matches chart id).
+          in: path
+          required: true
+          type: string
+        - name: from
+          description: Default is first data point
+          in: query
+          required: false
+          type: string
+        - name: to
+          description: Default is last data point
+          in: query
+          required: false
+          type: string
+        - name: resolution
+          in: query
+          required: false
+          type: string
+          enum:
+            - RESOLUTION_UNSPECIFIED
+            - DAY
+            - WEEK
+            - MONTH
+            - YEAR
+          default: RESOLUTION_UNSPECIFIED
+      tags:
+        - StatsService
+  /api/v1/pages/contracts:
+    get:
+      summary: Returns stats to be displayed on the contracts page.
+      operationId: StatsService_GetContractsPageStats
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/v1ContractsPageStats"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - StatsService
+  /api/v1/pages/interchain/main:
+    get:
+      summary: Returns interchain messaging stats to be displayed on the main page of interchain indexer.
+      operationId: StatsService_GetMainPageInterchainStats
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/v1MainPageInterchainStats"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - StatsService
+  /api/v1/pages/main:
+    get:
+      summary: Returns stats to be displayed on the main page of indexer.
+      operationId: StatsService_GetMainPageStats
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/v1MainPageStats"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - StatsService
+  /api/v1/pages/multichain/main:
+    get:
+      summary: Returns multichain-aggregated stats to be displayed on the main page of multichain indexer.
+      operationId: StatsService_GetMainPageMultichainStats
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/v1MainPageMultichainStats"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - StatsService
+  /api/v1/pages/transactions:
+    get:
+      summary: Returns stats to be displayed on the transactions page.
+      operationId: StatsService_GetTransactionsPageStats
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/v1TransactionsPageStats"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - StatsService
+  /api/v1/update-status:
+    get:
+      summary: |-
+        Returns the current status of chart data updates, broken down by
+        indexing dependency type (independent, blocks, internal transactions, etc.).
+      operationId: StatsService_GetUpdateStatus
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/v1UpdateStatus"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      tags:
+        - StatsService
+  /health:
+    get:
+      summary: |-
+        If the requested service is unknown, the call will fail with status
+        NOT_FOUND.
+      operationId: Health_Check
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: "#/definitions/v1HealthCheckResponse"
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: "#/definitions/rpcStatus"
+      parameters:
+        - name: service
+          in: query
+          required: false
+          type: string
+      tags:
+        - Health
+definitions:
+  HealthCheckResponseServingStatus:
+    type: string
+    enum:
+      - UNKNOWN
+      - SERVING
+      - NOT_SERVING
+      - SERVICE_UNKNOWN
+    default: UNKNOWN
+    description: " - SERVICE_UNKNOWN: Used only by the Watch method."
+  protobufAny:
+    type: object
+    properties:
+      "@type":
+        type: string
+    additionalProperties: {}
+  rpcStatus:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      details:
+        type: array
+        items:
+          type: object
+          $ref: "#/definitions/protobufAny"
+  v1BatchUpdateChartRejection:
+    type: object
+    properties:
+      name:
+        type: string
+      reason:
+        type: string
+  v1BatchUpdateChartsRequest:
+    type: object
+    properties:
+      chart_names:
+        type: array
+        items:
+          type: string
+        description: Ids of specific charts to update.
+      update_all:
+        type: boolean
+        description: Will ignore `chart_names` and update all charts.
+      from:
+        type: string
+        description: Start date for the update range. Default is today.
+      update_later:
+        type: boolean
+        description: |-
+          If true, update the charts later according to their
+          schedule rather than running it immediately.
+  v1BatchUpdateChartsResult:
+    type: object
+    properties:
+      total:
+        type: integer
+        format: int64
+        description: Total number of charts in the request.
+      total_rejected:
+        type: integer
+        format: int64
+        description: Total number of charts that were rejected.
+      accepted:
+        type: array
+        items:
+          type: string
+        description: Names/ids of charts that were accepted for update.
+      rejected:
+        type: array
+        items:
+          type: object
+          $ref: "#/definitions/v1BatchUpdateChartRejection"
+        description: Charts that were rejected, each with a reason.
+  v1ChartSubsetUpdateStatus:
+    type: string
+    enum:
+      - PENDING
+      - WAITING_FOR_STARTING_CONDITION
+      - QUEUED_FOR_INITIAL_UPDATE
+      - RUNNING_INITIAL_UPDATE
+      - COMPLETED_INITIAL_UPDATE
+    default: PENDING
+    title: |-
+      - PENDING: No actions were taken yet for some charts
+       - WAITING_FOR_STARTING_CONDITION: Some charts are waiting for starting condition
+       - QUEUED_FOR_INITIAL_UPDATE: Some charts are waiting for their turn to be updated
+       - RUNNING_INITIAL_UPDATE: Some charts are still running initial update
+       - COMPLETED_INITIAL_UPDATE: Initial updates were completed for all charts
+  v1ContractsPageStats:
+    type: object
+    properties:
+      total_contracts:
+        $ref: "#/definitions/v1Counter"
+      new_contracts_24h:
+        $ref: "#/definitions/v1Counter"
+      total_verified_contracts:
+        $ref: "#/definitions/v1Counter"
+      new_verified_contracts_24h:
+        $ref: "#/definitions/v1Counter"
+    description: |-
+      Pre-assembled set of statistics for the contracts page.
+      Fields are optional because individual charts may be disabled.
+  v1Counter:
+    type: object
+    properties:
+      id:
+        type: string
+      value:
+        type: string
+      title:
+        type: string
+      units:
+        type: string
+        description: Measurement units (e.g. "seconds", "ETH"), if applicable.
+      description:
+        type: string
+  v1Counters:
+    type: object
+    properties:
+      counters:
+        type: array
+        items:
+          type: object
+          $ref: "#/definitions/v1Counter"
+  v1HealthCheckResponse:
+    type: object
+    properties:
+      status:
+        $ref: "#/definitions/HealthCheckResponseServingStatus"
+  v1LineChart:
+    type: object
+    properties:
+      chart:
+        type: array
+        items:
+          type: object
+          $ref: "#/definitions/v1Point"
+      info:
+        $ref: "#/definitions/v1LineChartInfo"
+    description: "A line chart: its metadata and the series of data points."
+  v1LineChartInfo:
+    type: object
+    properties:
+      id:
+        type: string
+      title:
+        type: string
+      description:
+        type: string
+      units:
+        type: string
+      resolutions:
+        type: array
+        items:
+          type: string
+        description: Available time resolutions for this chart (e.g. "DAY", "WEEK").
+    description: Metadata describing a line chart.
+  v1LineChartSection:
+    type: object
+    properties:
+      id:
+        type: string
+      title:
+        type: string
+      charts:
+        type: array
+        items:
+          type: object
+          $ref: "#/definitions/v1LineChartInfo"
+    description: |-
+      A named group of related line charts.
+      Mainly intended for corresponding UI layout.
+  v1LineCharts:
+    type: object
+    properties:
+      sections:
+        type: array
+        items:
+          type: object
+          $ref: "#/definitions/v1LineChartSection"
+  v1MainPageInterchainStats:
+    type: object
+    properties:
+      total_interchain_messages:
+        $ref: "#/definitions/v1Counter"
+      total_interchain_messages_sent:
+        $ref: "#/definitions/v1Counter"
+      total_interchain_messages_received:
+        $ref: "#/definitions/v1Counter"
+    description: |-
+      Interchain messaging statistics for the main page.
+      Fields are optional because individual charts may be disabled.
+  v1MainPageMultichainStats:
+    type: object
+    properties:
+      total_multichain_txns:
+        $ref: "#/definitions/v1Counter"
+      total_multichain_addresses:
+        $ref: "#/definitions/v1Counter"
+      yesterday_txns_multichain:
+        $ref: "#/definitions/v1Counter"
+      new_txns_multichain_window:
+        $ref: "#/definitions/v1LineChart"
+    description: |-
+      Multichain-aggregated statistics for the main page of multichain indexer.
+      Fields are optional because individual charts may be disabled.
+  v1MainPageStats:
+    type: object
+    properties:
+      average_block_time:
+        $ref: "#/definitions/v1Counter"
+      total_addresses:
+        $ref: "#/definitions/v1Counter"
+      total_blocks:
+        $ref: "#/definitions/v1Counter"
+      total_transactions:
+        $ref: "#/definitions/v1Counter"
+      yesterday_transactions:
+        $ref: "#/definitions/v1Counter"
+      total_operational_transactions:
+        $ref: "#/definitions/v1Counter"
+      yesterday_operational_transactions:
+        $ref: "#/definitions/v1Counter"
+      op_stack_total_operational_transactions:
+        $ref: "#/definitions/v1Counter"
+        description: OP-Stack-specific variants of operational transaction counters.
+      op_stack_yesterday_operational_transactions:
+        $ref: "#/definitions/v1Counter"
+      daily_new_transactions:
+        $ref: "#/definitions/v1LineChart"
+      daily_new_operational_transactions:
+        $ref: "#/definitions/v1LineChart"
+      op_stack_daily_new_operational_transactions:
+        $ref: "#/definitions/v1LineChart"
+    description: |-
+      Pre-assembled set of statistics for the main indexer page.
+      Fields are optional because individual charts may be disabled.
+  v1Point:
+    type: object
+    properties:
+      date:
+        type: string
+        description: Start date of the period this point covers.
+      date_to:
+        type: string
+        description: |-
+          End date of the period (relevant for aggregated resolutions
+          like WEEK, MONTH, YEAR; equal to `date` for DAY resolution).
+      value:
+        type: string
+      is_approximate:
+        type: boolean
+        description: |-
+          True when the value is an approximation (i.e. the period is
+          not yet complete).
+    description: |-
+      A single data point on a line chart.
+      All integers are encoded as strings to prevent data loss.
+  v1Resolution:
+    type: string
+    enum:
+      - RESOLUTION_UNSPECIFIED
+      - DAY
+      - WEEK
+      - MONTH
+      - YEAR
+    default: RESOLUTION_UNSPECIFIED
+  v1TransactionsPageStats:
+    type: object
+    properties:
+      pending_transactions_30m:
+        $ref: "#/definitions/v1Counter"
+      transactions_fee_24h:
+        $ref: "#/definitions/v1Counter"
+      average_transactions_fee_24h:
+        $ref: "#/definitions/v1Counter"
+      transactions_24h:
+        $ref: "#/definitions/v1Counter"
+      operational_transactions_24h:
+        $ref: "#/definitions/v1Counter"
+      op_stack_operational_transactions_24h:
+        $ref: "#/definitions/v1Counter"
+      total_zetachain_cross_chain_txns:
+        $ref: "#/definitions/v1Counter"
+      new_zetachain_cross_chain_txns_24h:
+        $ref: "#/definitions/v1Counter"
+      pending_zetachain_cross_chain_txns:
+        $ref: "#/definitions/v1Counter"
+    description: |-
+      Pre-assembled set of statistics for the transactions page.
+      Fields are optional because individual charts may be disabled.
+  v1UpdateStatus:
+    type: object
+    properties:
+      all_status:
+        $ref: "#/definitions/v1ChartSubsetUpdateStatus"
+        title: Status of all enabled charts
+      independent_status:
+        $ref: "#/definitions/v1ChartSubsetUpdateStatus"
+        title: Status of all enabled charts that are independent from any indexing
+      blocks_dependent_status:
+        $ref: "#/definitions/v1ChartSubsetUpdateStatus"
+        title: Status of all enabled charts that depend on indexing blocks
+      internal_transactions_dependent_status:
+        $ref: "#/definitions/v1ChartSubsetUpdateStatus"
+        title: Status of all enabled charts that depend on indexing internal transactions and blocks
+      user_ops_dependent_status:
+        $ref: "#/definitions/v1ChartSubsetUpdateStatus"
+        title: Status of all enabled charts that depend on indexing user operations and internal transactions
+      zetachain_cctx_dependent_status:
+        $ref: "#/definitions/v1ChartSubsetUpdateStatus"
+        title: Status of all enabled charts that depend on indexing zetachain cctx
+    title: |-
+      Each field represents status of charts with corresponding dependency
+      as well as all charts with weaker requirements
+securityDefinitions:
+  ApiKeyAuth:
+    type: apiKey
+    name: x-api-key
+    in: header
+externalDocs:
+  description: More about blockscout microservices
+  url: https://github.com/blockscout/blockscout-rs

--- a/packages/zenko/index.ts
+++ b/packages/zenko/index.ts
@@ -3,6 +3,7 @@ export {
   type OpenAPISpec,
   type GenerateOptions,
   type TypesConfig,
+  type SchemaVersion,
 } from "./src/zenko"
 export {
   type PathFn,

--- a/packages/zenko/src/__tests__/cli.test.ts
+++ b/packages/zenko/src/__tests__/cli.test.ts
@@ -3,6 +3,7 @@ import { execSync } from "child_process"
 import * as fs from "fs"
 import * as path from "path"
 import {
+  blockscoutYamlPath,
   dateEnumYamlPath,
   petstoreYamlPath,
   tictactoeYamlPath,
@@ -501,5 +502,83 @@ describe("CLI", () => {
     // Version should remain closed
     expect(output).toContain("export const Version = z.enum([")
     expect(output).not.toContain("const VersionKnown =")
+  })
+
+  test("help text includes schemaVersion", () => {
+    const cliPath = path.join(process.cwd(), "src/cli.ts")
+    const output = execSync(`bun run ${cliPath} --help`, {
+      encoding: "utf8",
+    })
+
+    expect(output).toContain("schemaVersion")
+    expect(output).toContain("--schema-version")
+  })
+
+  test("supports schemaVersion auto in config file", () => {
+    const cliPath = path.join(process.cwd(), "src/cli.ts")
+    const configDir = path.join(tempDir, "schema-version-auto-config")
+    fs.mkdirSync(configDir, { recursive: true })
+
+    const configPath = path.join(configDir, "zenko.config.json")
+    const configOutput = path.join(configDir, "blockscout.gen.ts")
+    const config = {
+      schemas: [
+        {
+          input: path.relative(configDir, blockscoutYamlPath),
+          output: "blockscout.gen.ts",
+          schemaVersion: "auto",
+        },
+      ],
+    }
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+
+    execSync(`bun run ${cliPath} --config ${configPath}`, {
+      encoding: "utf8",
+    })
+
+    const output = fs.readFileSync(configOutput, "utf8")
+    expect(output).toContain("// Generated Zod Schemas")
+    expect(output).toContain("export const v1Counters")
+  })
+
+  test("supports schemaVersion oas3 in config file", () => {
+    const cliPath = path.join(process.cwd(), "src/cli.ts")
+    const configDir = path.join(tempDir, "schema-version-oas3-config")
+    fs.mkdirSync(configDir, { recursive: true })
+
+    const configPath = path.join(configDir, "zenko.config.json")
+    const configOutput = path.join(configDir, "blockscout.gen.ts")
+    const config = {
+      schemas: [
+        {
+          input: path.relative(configDir, blockscoutYamlPath),
+          output: "blockscout.gen.ts",
+          schemaVersion: "oas3",
+        },
+      ],
+    }
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+
+    execSync(`bun run ${cliPath} --config ${configPath}`, {
+      encoding: "utf8",
+    })
+
+    const output = fs.readFileSync(configOutput, "utf8")
+    expect(output).not.toContain("// Generated Zod Schemas")
+    expect(output).toContain("OperationErrors<{ defaultError: undefined }>")
+  })
+
+  test("supports --schema-version on single-file CLI path", () => {
+    const cliPath = path.join(process.cwd(), "src/cli.ts")
+    const outputPath = path.join(tempDir, "blockscout-oas3-cli.ts")
+
+    execSync(
+      `bun run ${cliPath} ${blockscoutYamlPath} ${outputPath} --schema-version oas3`,
+      { encoding: "utf8" }
+    )
+
+    const output = fs.readFileSync(outputPath, "utf8")
+    expect(output).not.toContain("// Generated Zod Schemas")
+    expect(output).toContain("OperationErrors<{ defaultError: undefined }>")
   })
 })

--- a/packages/zenko/src/__tests__/schema-version-oas2.test.ts
+++ b/packages/zenko/src/__tests__/schema-version-oas2.test.ts
@@ -1,0 +1,319 @@
+import { describe, test, expect } from "bun:test"
+
+import { blockscoutYamlPath } from "@zenko/specs"
+
+import { generate, type OpenAPISpec } from "../zenko"
+import {
+  normalizeOas2ToOas3,
+  normalizeSpecForSchemaVersion,
+  resolveSchemaVersion,
+} from "../utils/normalize-oas2"
+import { loadOpenAPISpec } from "../utils/yaml"
+
+describe("resolveSchemaVersion", () => {
+  const swagger2 = { swagger: "2.0", info: {}, paths: {} } as OpenAPISpec
+  const openapi3 = { openapi: "3.0.0", info: {}, paths: {} } as OpenAPISpec
+
+  test("auto detects swagger 2.0", () => {
+    expect(resolveSchemaVersion(swagger2, "auto")).toBe("oas2")
+  })
+
+  test("auto treats openapi as oas3", () => {
+    expect(resolveSchemaVersion(openapi3, "auto")).toBe("oas3")
+  })
+
+  test("explicit oas2/oas3 override auto", () => {
+    expect(resolveSchemaVersion(openapi3, "oas2")).toBe("oas2")
+    expect(resolveSchemaVersion(swagger2, "oas3")).toBe("oas3")
+  })
+
+  test("normalizeSpecForSchemaVersion only rewrites oas2", () => {
+    const asOas2 = normalizeSpecForSchemaVersion(swagger2, "auto")
+    expect(asOas2.openapi).toBe("3.0.0")
+    expect(asOas2.swagger).toBeUndefined()
+
+    const leftAlone = normalizeSpecForSchemaVersion(openapi3, "auto")
+    expect(leftAlone).toBe(openapi3)
+  })
+})
+
+describe("normalizeOas2ToOas3", () => {
+  test("moves definitions and response schemas into OAS3 shape", () => {
+    const input: OpenAPISpec = {
+      swagger: "2.0",
+      info: { title: "Demo", version: "1.0.0" },
+      consumes: ["application/json"],
+      produces: ["application/json"],
+      paths: {
+        "/pets": {
+          post: {
+            operationId: "createPet",
+            parameters: [
+              {
+                name: "body",
+                in: "body",
+                required: true,
+                schema: { $ref: "#/definitions/Pet" },
+              },
+              {
+                name: "limit",
+                in: "query",
+                type: "integer",
+                required: false,
+              },
+            ],
+            responses: {
+              "200": {
+                description: "ok",
+                schema: { $ref: "#/definitions/Pet" },
+              },
+              default: {
+                description: "error",
+                schema: { $ref: "#/definitions/Error" },
+              },
+            },
+          },
+        },
+      },
+      definitions: {
+        Pet: {
+          type: "object",
+          properties: { name: { type: "string" } },
+        },
+        Error: {
+          type: "object",
+          properties: { message: { type: "string" } },
+        },
+      },
+      securityDefinitions: {
+        ApiKeyAuth: { type: "apiKey", name: "x-api-key", in: "header" },
+      },
+    }
+
+    const normalized = normalizeOas2ToOas3(input)
+
+    expect(normalized.openapi).toBe("3.0.0")
+    expect(normalized.swagger).toBeUndefined()
+    expect(normalized.definitions).toBeUndefined()
+    expect(normalized.components?.schemas?.Pet).toEqual({
+      type: "object",
+      properties: { name: { type: "string" } },
+    })
+    expect(normalized.components?.securitySchemes?.ApiKeyAuth).toEqual({
+      type: "apiKey",
+      name: "x-api-key",
+      in: "header",
+    })
+
+    const operation = (normalized.paths["/pets"] as any).post
+    expect(operation.requestBody.content["application/json"].schema).toEqual({
+      $ref: "#/components/schemas/Pet",
+    })
+    expect(operation.parameters).toEqual([
+      {
+        name: "limit",
+        in: "query",
+        required: false,
+        schema: { type: "integer" },
+      },
+    ])
+    expect(
+      operation.responses["200"].content["application/json"].schema
+    ).toEqual({
+      $ref: "#/components/schemas/Pet",
+    })
+    expect(
+      operation.responses.default.content["application/json"].schema
+    ).toEqual({
+      $ref: "#/components/schemas/Error",
+    })
+
+    // Original input must not be mutated
+    expect(input.definitions).toBeDefined()
+    expect(input.swagger).toBe("2.0")
+  })
+
+  test("converts formData parameters into multipart requestBody", () => {
+    const normalized = normalizeOas2ToOas3({
+      swagger: "2.0",
+      info: {},
+      paths: {
+        "/upload": {
+          post: {
+            operationId: "upload",
+            parameters: [
+              {
+                name: "file",
+                in: "formData",
+                type: "file",
+                required: true,
+              },
+              {
+                name: "note",
+                in: "formData",
+                type: "string",
+              },
+            ],
+            responses: { "204": { description: "ok" } },
+          },
+        },
+      },
+    })
+
+    const operation = (normalized.paths["/upload"] as any).post
+    expect(operation.requestBody.content["multipart/form-data"].schema).toEqual(
+      {
+        type: "object",
+        properties: {
+          file: { type: "string", format: "binary" },
+          note: { type: "string" },
+        },
+        required: ["file"],
+      }
+    )
+    expect(operation.parameters).toEqual([])
+  })
+
+  test("resolves reusable parameters and responses", () => {
+    const input = {
+      swagger: "2.0",
+      info: {},
+      parameters: {
+        PetBody: {
+          name: "body",
+          in: "body",
+          required: true,
+          schema: { $ref: "#/definitions/Pet" },
+        },
+        Limit: {
+          name: "limit",
+          in: "query",
+          type: "integer",
+        },
+      },
+      responses: {
+        PetResponse: {
+          description: "ok",
+          schema: { $ref: "#/definitions/Pet" },
+        },
+        ErrorResponse: {
+          description: "error",
+          schema: { $ref: "#/definitions/Error" },
+        },
+      },
+      paths: {
+        "/pets": {
+          post: {
+            operationId: "createPet",
+            parameters: [
+              { $ref: "#/parameters/PetBody" },
+              { $ref: "#/parameters/Limit" },
+            ],
+            responses: {
+              "200": { $ref: "#/responses/PetResponse" },
+              default: { $ref: "#/responses/ErrorResponse" },
+            },
+          },
+        },
+      },
+      definitions: {
+        Pet: { type: "object", properties: { name: { type: "string" } } },
+        Error: {
+          type: "object",
+          properties: { message: { type: "string" } },
+        },
+      },
+    } as OpenAPISpec
+
+    const normalized = normalizeOas2ToOas3(input)
+    const operation = (normalized.paths["/pets"] as any).post
+
+    expect(operation.requestBody.content["application/json"].schema).toEqual({
+      $ref: "#/components/schemas/Pet",
+    })
+    expect(operation.parameters).toEqual([
+      {
+        name: "limit",
+        in: "query",
+        schema: { type: "integer" },
+      },
+    ])
+    expect(
+      operation.responses["200"].content["application/json"].schema
+    ).toEqual({ $ref: "#/components/schemas/Pet" })
+    expect(
+      operation.responses.default.content["application/json"].schema
+    ).toEqual({ $ref: "#/components/schemas/Error" })
+
+    const result = generate(input)
+    expect(result).toContain(
+      "typeof Pet,\n  typeof Pet,\n  undefined,\n  OperationErrors<{ defaultError: typeof Error }>"
+    )
+  })
+
+  test("converts inherited path-level body parameters", () => {
+    const input: OpenAPISpec = {
+      swagger: "2.0",
+      info: {},
+      paths: {
+        "/pets": {
+          parameters: [
+            {
+              name: "body",
+              in: "body",
+              required: true,
+              schema: { $ref: "#/definitions/Pet" },
+            },
+          ],
+          post: {
+            operationId: "createPet",
+            responses: {
+              "200": {
+                description: "ok",
+                schema: { $ref: "#/definitions/Pet" },
+              },
+            },
+          },
+        },
+      },
+      definitions: {
+        Pet: { type: "object", properties: { name: { type: "string" } } },
+      },
+    }
+
+    const normalized = normalizeOas2ToOas3(input)
+    const operation = (normalized.paths["/pets"] as any).post
+
+    expect(operation.requestBody.content["application/json"].schema).toEqual({
+      $ref: "#/components/schemas/Pet",
+    })
+    expect(operation.parameters).toEqual([])
+
+    const result = generate(input)
+    expect(result).toContain("typeof Pet,\n  typeof Pet,\n  undefined")
+  })
+})
+
+describe("schemaVersion with blockscout (Swagger 2.0)", () => {
+  const blockscoutSpec = loadOpenAPISpec(blockscoutYamlPath)
+
+  test("auto generates response schemas and types from definitions", () => {
+    const result = generate(blockscoutSpec, { schemaVersion: "auto" })
+
+    expect(result).toContain("// Generated Zod Schemas")
+    expect(result).toContain("export const v1Counters")
+    expect(result).toContain("export const rpcStatus")
+    expect(result).toContain("export type StatsService_GetCountersOperation")
+    expect(result).toContain("typeof v1Counters")
+    expect(result).toContain("typeof rpcStatus")
+    expect(result).toContain("export const securitySchemes")
+    expect(result).toContain("ApiKeyAuth")
+  })
+
+  test("oas3 skips normalization and leaves responses undefined", () => {
+    const result = generate(blockscoutSpec, { schemaVersion: "oas3" })
+
+    expect(result).not.toContain("// Generated Zod Schemas")
+    expect(result).toContain("OperationErrors<{ defaultError: undefined }>")
+  })
+})

--- a/packages/zenko/src/__tests__/schema-version-oas2.test.ts
+++ b/packages/zenko/src/__tests__/schema-version-oas2.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test"
+import { describe, test, expect, mock } from "bun:test"
 
 import { blockscoutYamlPath } from "@zenko/specs"
 
@@ -368,6 +368,172 @@ describe("normalizeOas2ToOas3", () => {
 
     const result = generate(input)
     expect(result).toContain("typeof Pet,\n  typeof Pet,\n  undefined")
+  })
+
+  test("operation-level parameters override path-level parameters", () => {
+    const normalized = normalizeOas2ToOas3({
+      swagger: "2.0",
+      info: {},
+      paths: {
+        "/items": {
+          parameters: [
+            {
+              name: "X-Token",
+              in: "header",
+              type: "string",
+              required: false,
+            },
+            {
+              name: "body",
+              in: "body",
+              required: false,
+              schema: {
+                type: "object",
+                properties: { old: { type: "string" } },
+              },
+            },
+          ],
+          post: {
+            operationId: "createItem",
+            parameters: [
+              {
+                name: "X-Token",
+                in: "header",
+                type: "string",
+                required: true,
+              },
+              {
+                name: "body",
+                in: "body",
+                required: true,
+                schema: { $ref: "#/definitions/Item" },
+              },
+            ],
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+      definitions: {
+        Item: { type: "object", properties: { name: { type: "string" } } },
+      },
+    })
+
+    const operation = (normalized.paths["/items"] as any).post
+    expect(operation.parameters).toEqual([
+      {
+        name: "X-Token",
+        in: "header",
+        required: true,
+        schema: { type: "string" },
+      },
+    ])
+    expect(operation.requestBody.content["application/json"].schema).toEqual({
+      $ref: "#/components/schemas/Item",
+    })
+  })
+
+  test("throws on unresolved parameter references", () => {
+    expect(() =>
+      normalizeOas2ToOas3({
+        swagger: "2.0",
+        info: {},
+        paths: {
+          "/pets": {
+            get: {
+              operationId: "listPets",
+              parameters: [{ $ref: "#/parameters/Missing" }],
+              responses: { "200": { description: "ok" } },
+            },
+          },
+        },
+      })
+    ).toThrow('unresolved reference "#/parameters/Missing"')
+  })
+
+  test("converts basic and oauth2 securityDefinitions to OAS3 shape", () => {
+    const normalized = normalizeOas2ToOas3({
+      swagger: "2.0",
+      info: {},
+      paths: {},
+      securityDefinitions: {
+        BasicAuth: { type: "basic" },
+        OAuth: {
+          type: "oauth2",
+          flow: "accessCode",
+          authorizationUrl: "https://example.com/oauth/authorize",
+          tokenUrl: "https://example.com/oauth/token",
+          scopes: { read: "Read access" },
+        },
+      },
+    })
+
+    expect(normalized.components?.securitySchemes?.BasicAuth).toEqual({
+      type: "http",
+      scheme: "basic",
+    })
+    expect(normalized.components?.securitySchemes?.OAuth).toEqual({
+      type: "oauth2",
+      flows: {
+        authorizationCode: {
+          authorizationUrl: "https://example.com/oauth/authorize",
+          tokenUrl: "https://example.com/oauth/token",
+          scopes: { read: "Read access" },
+        },
+      },
+    })
+
+    const result = generate(normalized, { schemaVersion: "oas3" })
+    expect(result).toContain('type: "http"')
+    expect(result).toContain('scheme: "basic"')
+    expect(result).toContain('type: "oauth2"')
+    expect(result).toContain('"authorizationCode"')
+  })
+
+  test("falls back to application/json for unsupported request body media types", () => {
+    const input: OpenAPISpec = {
+      swagger: "2.0",
+      info: {},
+      consumes: ["application/xml"],
+      paths: {
+        "/items": {
+          post: {
+            operationId: "createItem",
+            parameters: [
+              {
+                name: "body",
+                in: "body",
+                required: true,
+                schema: {
+                  type: "object",
+                  properties: { name: { type: "string" } },
+                },
+              },
+            ],
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    }
+
+    const warn = mock(() => {})
+    const originalWarn = console.warn
+    console.warn = warn
+
+    try {
+      const normalized = normalizeOas2ToOas3(input)
+      const operation = (normalized.paths["/items"] as any).post
+      expect(operation.requestBody.content["application/json"].schema).toEqual({
+        type: "object",
+        properties: { name: { type: "string" } },
+      })
+      expect(warn).toHaveBeenCalled()
+
+      const result = generate(input, { schemaVersion: "auto" })
+      expect(result).toContain("export const createItem:")
+      expect(result).toContain("request:")
+    } finally {
+      console.warn = originalWarn
+    }
   })
 })
 

--- a/packages/zenko/src/__tests__/schema-version-oas2.test.ts
+++ b/packages/zenko/src/__tests__/schema-version-oas2.test.ts
@@ -174,6 +174,83 @@ describe("normalizeOas2ToOas3", () => {
     expect(operation.parameters).toEqual([])
   })
 
+  test("uses application/x-www-form-urlencoded when consumes specifies it", () => {
+    const normalized = normalizeOas2ToOas3({
+      swagger: "2.0",
+      info: {},
+      consumes: ["application/x-www-form-urlencoded"],
+      paths: {
+        "/login": {
+          post: {
+            operationId: "login",
+            parameters: [
+              {
+                name: "username",
+                in: "formData",
+                type: "string",
+                required: true,
+              },
+              {
+                name: "password",
+                in: "formData",
+                type: "string",
+                required: true,
+              },
+            ],
+            responses: { "204": { description: "ok" } },
+          },
+        },
+      },
+    })
+
+    const operation = (normalized.paths["/login"] as any).post
+    expect(
+      operation.requestBody.content["application/x-www-form-urlencoded"].schema
+    ).toEqual({
+      type: "object",
+      properties: {
+        username: { type: "string" },
+        password: { type: "string" },
+      },
+      required: ["username", "password"],
+    })
+    expect(operation.requestBody.content["multipart/form-data"]).toBeUndefined()
+  })
+
+  test("operation consumes override global form encoding", () => {
+    const normalized = normalizeOas2ToOas3({
+      swagger: "2.0",
+      info: {},
+      consumes: ["multipart/form-data"],
+      paths: {
+        "/contact": {
+          post: {
+            operationId: "submitContact",
+            consumes: ["application/x-www-form-urlencoded"],
+            parameters: [
+              {
+                name: "email",
+                in: "formData",
+                type: "string",
+                required: true,
+              },
+            ],
+            responses: { "204": { description: "ok" } },
+          },
+        },
+      },
+    })
+
+    const operation = (normalized.paths["/contact"] as any).post
+    expect(
+      operation.requestBody.content["application/x-www-form-urlencoded"].schema
+    ).toEqual({
+      type: "object",
+      properties: { email: { type: "string" } },
+      required: ["email"],
+    })
+  })
+
   test("resolves reusable parameters and responses", () => {
     const input = {
       swagger: "2.0",

--- a/packages/zenko/src/cli.ts
+++ b/packages/zenko/src/cli.ts
@@ -8,6 +8,7 @@ import {
   type OpenAPISpec,
   type TypesConfig,
   type EnumConfig,
+  type SchemaVersion,
 } from "./zenko.js"
 import { generateTreatyModule } from "./treaty-generator.js"
 
@@ -21,6 +22,7 @@ type CliConfigEntry = {
   types?: TypesConfig
   operationIds?: string[]
   openEnums?: boolean | string[] | EnumConfig
+  schemaVersion?: SchemaVersion
 }
 
 type CliConfigFile = {
@@ -179,7 +181,7 @@ function printHelp() {
   console.log("")
   console.log("Config file format:")
   console.log(
-    '  {"types"?: { emit?, helpers?, helpersOutput?, optionalType?, treeShake? }, "schemas": [{ input, output, strictDates?, strictNumeric?, dateTimeOffset?, types? }] }'
+    '  {"types"?: { emit?, helpers?, helpersOutput?, optionalType?, treeShake? }, "schemas": [{ input, output, strictDates?, strictNumeric?, dateTimeOffset?, schemaVersion?, types? }] }'
   )
 }
 
@@ -234,6 +236,7 @@ async function runFromConfig(parsed: ParsedArgs) {
       typesConfig,
       operationIds: entry.operationIds,
       openEnums: entry.openEnums,
+      schemaVersion: entry.schemaVersion,
     })
 
     if (entry.treatyOutput) {
@@ -307,6 +310,7 @@ async function generateSingle(options: {
   typesConfig?: TypesConfig
   operationIds?: string[]
   openEnums?: boolean | string[] | EnumConfig
+  schemaVersion?: SchemaVersion
 }) {
   const {
     inputFile,
@@ -317,6 +321,7 @@ async function generateSingle(options: {
     typesConfig,
     operationIds,
     openEnums,
+    schemaVersion,
   } = options
   const resolvedInput = path.resolve(inputFile)
   const resolvedOutput = path.resolve(outputFile)
@@ -329,6 +334,7 @@ async function generateSingle(options: {
     types: typesConfig,
     operationIds,
     openEnums,
+    schemaVersion,
   })
 
   fs.mkdirSync(path.dirname(resolvedOutput), { recursive: true })

--- a/packages/zenko/src/cli.ts
+++ b/packages/zenko/src/cli.ts
@@ -34,6 +34,7 @@ type ParsedArgs = {
   showHelp: boolean
   strictDates: boolean
   strictNumeric: boolean
+  schemaVersion?: SchemaVersion
   configPath?: string
   positional: string[]
 }
@@ -111,6 +112,7 @@ async function main() {
         outputFile,
         strictDates: parsed.strictDates,
         strictNumeric: parsed.strictNumeric,
+        schemaVersion: parsed.schemaVersion,
       })
     }
   } catch (error) {
@@ -145,6 +147,16 @@ function parseArgs(args: string[]): ParsedArgs {
       continue
     }
 
+    if (arg === "--schema-version") {
+      const next = args[index + 1]
+      if (!next || !["auto", "oas2", "oas3"].includes(next)) {
+        throw new Error("--schema-version requires auto, oas2, or oas3")
+      }
+      parsed.schemaVersion = next as SchemaVersion
+      index += 1
+      continue
+    }
+
     if (arg === "--config" || arg === "-c") {
       const next = args[index + 1]
       if (!next) {
@@ -174,6 +186,9 @@ function printHelp() {
   )
   console.log(
     "  --strict-numeric    Preserve numeric min/max bounds (can be set per config entry)"
+  )
+  console.log(
+    "  --schema-version    Swagger/OpenAPI version handling: auto, oas2, or oas3"
   )
   console.log(
     "  -c, --config        Path to config file (JSON, YAML, or JS module)"

--- a/packages/zenko/src/utils/normalize-oas2.ts
+++ b/packages/zenko/src/utils/normalize-oas2.ts
@@ -82,10 +82,10 @@ export function normalizeOas2ToOas3(spec: OpenAPISpec): OpenAPISpec {
     ...(cloned.definitions as JsonObject | undefined),
     ...(components.schemas as JsonObject | undefined),
   }
-  components.securitySchemes = {
-    ...(cloned.securityDefinitions as JsonObject | undefined),
-    ...(components.securitySchemes as JsonObject | undefined),
-  }
+  components.securitySchemes = convertSecurityDefinitions(
+    cloned.securityDefinitions,
+    components.securitySchemes as JsonObject | undefined
+  )
 
   if (isPlainObject(cloned.paths)) {
     for (const pathItem of Object.values(cloned.paths)) {
@@ -180,11 +180,12 @@ function normalizeOperation(
 
     if (!operation.requestBody) {
       if (bodyParam) {
+        const requestMediaType = pickRequestBodyMediaType(consumes, operation)
         operation.requestBody = {
           description: bodyParam.description,
           required: bodyParam.required ?? false,
           content: {
-            [pickMediaType(consumes)]: {
+            [requestMediaType]: {
               schema: bodyParam.schema ?? {},
             },
           },
@@ -265,7 +266,11 @@ function resolveOas2Reference(
 
   const name = value.$ref.slice(prefix.length)
   const resolved = definitions[name]
-  if (resolved === undefined) return value
+  if (resolved === undefined) {
+    throw new Error(
+      `Swagger 2.0 normalization: unresolved reference "${value.$ref}"`
+    )
+  }
 
   seen.add(value.$ref)
   const dereferenced = resolveOas2Reference(resolved, definitions, prefix, seen)
@@ -355,6 +360,28 @@ function pickMediaType(types: string[]): string {
 
 const FORM_URLENCODED = "application/x-www-form-urlencoded"
 const MULTIPART_FORM_DATA = "multipart/form-data"
+const SUPPORTED_REQUEST_MEDIA_TYPES = new Set([
+  DEFAULT_MEDIA_TYPE,
+  MULTIPART_FORM_DATA,
+  FORM_URLENCODED,
+])
+
+function pickRequestBodyMediaType(
+  consumes: string[],
+  operation: JsonObject
+): string {
+  const picked = pickMediaType(consumes)
+  if (SUPPORTED_REQUEST_MEDIA_TYPES.has(picked)) return picked
+
+  const operationId =
+    typeof operation.operationId === "string"
+      ? operation.operationId
+      : "unknown"
+  console.warn(
+    `Swagger 2.0 normalization: operation "${operationId}" consumes "${picked}" which Zenko cannot generate request types for; falling back to application/json`
+  )
+  return DEFAULT_MEDIA_TYPE
+}
 
 function pickFormDataMediaType(
   consumes: string[],
@@ -377,6 +404,71 @@ function isFileFormParam(param: JsonObject): boolean {
       param.schema.type === "string" &&
       param.schema.format === "binary")
   )
+}
+
+function convertSecurityDefinitions(
+  oas2Definitions: unknown,
+  existing: JsonObject | undefined
+): JsonObject {
+  const result: JsonObject = { ...existing }
+  if (!isPlainObject(oas2Definitions)) return result
+
+  for (const [name, scheme] of Object.entries(oas2Definitions)) {
+    if (!isPlainObject(scheme)) continue
+    result[name] = convertSecurityScheme(scheme)
+  }
+
+  return result
+}
+
+function convertSecurityScheme(scheme: JsonObject): JsonObject {
+  if (scheme.type === "basic") {
+    return {
+      ...(scheme.description !== undefined
+        ? { description: scheme.description }
+        : {}),
+      type: "http",
+      scheme: "basic",
+    }
+  }
+
+  if (scheme.type === "oauth2") {
+    return {
+      ...(scheme.description !== undefined
+        ? { description: scheme.description }
+        : {}),
+      type: "oauth2",
+      flows: convertOauth2Flows(scheme),
+    }
+  }
+
+  return { ...scheme }
+}
+
+function convertOauth2Flows(scheme: JsonObject): JsonObject {
+  const flow = typeof scheme.flow === "string" ? scheme.flow : undefined
+  const scopes = isPlainObject(scheme.scopes) ? scheme.scopes : {}
+  const flowDef: JsonObject = { scopes }
+
+  if (scheme.authorizationUrl !== undefined) {
+    flowDef.authorizationUrl = scheme.authorizationUrl
+  }
+  if (scheme.tokenUrl !== undefined) {
+    flowDef.tokenUrl = scheme.tokenUrl
+  }
+
+  switch (flow) {
+    case "implicit":
+      return { implicit: flowDef }
+    case "password":
+      return { password: flowDef }
+    case "application":
+      return { clientCredentials: flowDef }
+    case "accessCode":
+      return { authorizationCode: flowDef }
+    default:
+      return {}
+  }
 }
 
 function asStringArray(value: unknown): string[] | undefined {

--- a/packages/zenko/src/utils/normalize-oas2.ts
+++ b/packages/zenko/src/utils/normalize-oas2.ts
@@ -190,10 +190,11 @@ function normalizeOperation(
           },
         }
       } else if (formParams.length > 0) {
+        const formMediaType = pickFormDataMediaType(consumes, formParams)
         operation.requestBody = {
           required: formParams.some((p) => p.required),
           content: {
-            "multipart/form-data": {
+            [formMediaType]: {
               schema: formDataToSchema(formParams),
             },
           },
@@ -350,6 +351,32 @@ function rewriteDefinitionRefs(value: unknown): unknown {
 function pickMediaType(types: string[]): string {
   if (types.length === 0) return DEFAULT_MEDIA_TYPE
   return types.find((t) => t.includes("json")) ?? types[0] ?? DEFAULT_MEDIA_TYPE
+}
+
+const FORM_URLENCODED = "application/x-www-form-urlencoded"
+const MULTIPART_FORM_DATA = "multipart/form-data"
+
+function pickFormDataMediaType(
+  consumes: string[],
+  formParams: JsonObject[]
+): string {
+  if (formParams.some(isFileFormParam)) return MULTIPART_FORM_DATA
+
+  const formMediaTypes = consumes.filter(
+    (type) => type === FORM_URLENCODED || type === MULTIPART_FORM_DATA
+  )
+  if (formMediaTypes.includes(FORM_URLENCODED)) return FORM_URLENCODED
+  if (formMediaTypes.includes(MULTIPART_FORM_DATA)) return MULTIPART_FORM_DATA
+  return FORM_URLENCODED
+}
+
+function isFileFormParam(param: JsonObject): boolean {
+  return (
+    param.type === "file" ||
+    (isPlainObject(param.schema) &&
+      param.schema.type === "string" &&
+      param.schema.format === "binary")
+  )
 }
 
 function asStringArray(value: unknown): string[] | undefined {

--- a/packages/zenko/src/utils/normalize-oas2.ts
+++ b/packages/zenko/src/utils/normalize-oas2.ts
@@ -1,0 +1,379 @@
+import type { OpenAPISpec, SchemaVersion } from "../zenko"
+
+const DEFAULT_MEDIA_TYPE = "application/json"
+const DEFINITIONS_REF_PREFIX = "#/definitions/"
+const COMPONENTS_SCHEMAS_REF_PREFIX = "#/components/schemas/"
+const PARAMETERS_REF_PREFIX = "#/parameters/"
+const RESPONSES_REF_PREFIX = "#/responses/"
+
+const HTTP_METHODS = new Set([
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+])
+
+/** OAS2 parameter fields that become `schema` properties in OAS3. */
+const OAS2_SCHEMA_KEYS = [
+  "type",
+  "format",
+  "enum",
+  "items",
+  "default",
+  "minimum",
+  "maximum",
+  "exclusiveMinimum",
+  "exclusiveMaximum",
+  "minLength",
+  "maxLength",
+  "pattern",
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+  "multipleOf",
+  "additionalProperties",
+] as const
+
+type JsonObject = Record<string, unknown>
+
+/**
+ * Apply `schemaVersion` preprocessing: normalize Swagger 2.0 documents to an
+ * OpenAPI 3-shaped spec when needed. Leaves OAS3 documents unchanged.
+ */
+export function normalizeSpecForSchemaVersion(
+  spec: OpenAPISpec,
+  schemaVersion: SchemaVersion = "auto"
+): OpenAPISpec {
+  if (resolveSchemaVersion(spec, schemaVersion) === "oas2") {
+    return normalizeOas2ToOas3(spec)
+  }
+  return spec
+}
+
+export function resolveSchemaVersion(
+  spec: OpenAPISpec,
+  schemaVersion: SchemaVersion = "auto"
+): "oas3" | "oas2" {
+  if (schemaVersion !== "auto") return schemaVersion
+
+  const { swagger } = spec
+  if (swagger === "2.0" || swagger === 2) return "oas2"
+  return "oas3"
+}
+
+/**
+ * Convert a Swagger 2.0 document into an OpenAPI 3-shaped spec that the
+ * rest of Zenko can consume. Assumes JSON (or the first consumes/produces
+ * entry) for request/response bodies.
+ */
+export function normalizeOas2ToOas3(spec: OpenAPISpec): OpenAPISpec {
+  const cloned = structuredClone(spec) as JsonObject
+  const globalConsumes = asStringArray(cloned.consumes) ?? []
+  const globalProduces = asStringArray(cloned.produces) ?? []
+  const parameterDefinitions = asObject(cloned.parameters)
+  const responseDefinitions = asObject(cloned.responses)
+
+  const components = ensureObject(cloned, "components")
+  components.schemas = {
+    ...(cloned.definitions as JsonObject | undefined),
+    ...(components.schemas as JsonObject | undefined),
+  }
+  components.securitySchemes = {
+    ...(cloned.securityDefinitions as JsonObject | undefined),
+    ...(components.securitySchemes as JsonObject | undefined),
+  }
+
+  if (isPlainObject(cloned.paths)) {
+    for (const pathItem of Object.values(cloned.paths)) {
+      if (!isPlainObject(pathItem)) continue
+      normalizePathItem(
+        pathItem,
+        globalConsumes,
+        globalProduces,
+        parameterDefinitions,
+        responseDefinitions
+      )
+    }
+  }
+
+  delete cloned.swagger
+  delete cloned.definitions
+  delete cloned.securityDefinitions
+  delete cloned.parameters
+  delete cloned.responses
+  delete cloned.consumes
+  delete cloned.produces
+  cloned.openapi = cloned.openapi ?? "3.0.0"
+
+  return rewriteDefinitionRefs(cloned) as OpenAPISpec
+}
+
+function normalizePathItem(
+  pathItem: JsonObject,
+  globalConsumes: string[],
+  globalProduces: string[],
+  parameterDefinitions: JsonObject,
+  responseDefinitions: JsonObject
+): void {
+  const inheritedParameters = Array.isArray(pathItem.parameters)
+    ? pathItem.parameters
+    : []
+
+  for (const [method, operation] of Object.entries(pathItem)) {
+    if (!isHttpMethod(method) || !isPlainObject(operation)) continue
+    const operationParameters = Array.isArray(operation.parameters)
+      ? operation.parameters
+      : []
+    operation.parameters = mergeOas2Parameters(
+      inheritedParameters,
+      operationParameters,
+      parameterDefinitions
+    )
+    normalizeOperation(
+      operation,
+      globalConsumes,
+      globalProduces,
+      responseDefinitions
+    )
+  }
+
+  delete pathItem.parameters
+}
+
+function normalizeOperation(
+  operation: JsonObject,
+  globalConsumes: string[],
+  globalProduces: string[],
+  responseDefinitions: JsonObject
+): void {
+  const consumes = asStringArray(operation.consumes) ?? globalConsumes
+  const produces = asStringArray(operation.produces) ?? globalProduces
+
+  if (Array.isArray(operation.parameters)) {
+    let bodyParam: JsonObject | undefined
+    const formParams: JsonObject[] = []
+    const remaining: unknown[] = []
+
+    for (const raw of operation.parameters) {
+      const param = liftOas2Parameter(raw)
+      if (!isPlainObject(param)) {
+        remaining.push(param)
+        continue
+      }
+      if (param.in === "body") {
+        // Last body parameter wins (Swagger allows at most one).
+        bodyParam = param
+        continue
+      }
+      if (param.in === "formData") {
+        formParams.push(param)
+        continue
+      }
+      remaining.push(param)
+    }
+
+    operation.parameters = remaining
+
+    if (!operation.requestBody) {
+      if (bodyParam) {
+        operation.requestBody = {
+          description: bodyParam.description,
+          required: bodyParam.required ?? false,
+          content: {
+            [pickMediaType(consumes)]: {
+              schema: bodyParam.schema ?? {},
+            },
+          },
+        }
+      } else if (formParams.length > 0) {
+        operation.requestBody = {
+          required: formParams.some((p) => p.required),
+          content: {
+            "multipart/form-data": {
+              schema: formDataToSchema(formParams),
+            },
+          },
+        }
+      }
+    }
+  }
+
+  delete operation.consumes
+  delete operation.produces
+
+  if (isPlainObject(operation.responses)) {
+    const mediaType = pickMediaType(produces)
+    for (const [status, rawResponse] of Object.entries(operation.responses)) {
+      const response = resolveOas2Reference(
+        rawResponse,
+        responseDefinitions,
+        RESPONSES_REF_PREFIX
+      )
+      if (!isPlainObject(response)) continue
+      operation.responses[status] = response
+      if (response.schema === undefined || response.content !== undefined) {
+        continue
+      }
+      response.content = {
+        [mediaType]: { schema: response.schema },
+      }
+      delete response.schema
+    }
+  }
+}
+
+function mergeOas2Parameters(
+  inherited: unknown[],
+  operation: unknown[],
+  definitions: JsonObject
+): unknown[] {
+  const merged = new Map<string, unknown>()
+  let unkeyedIndex = 0
+
+  for (const raw of [...inherited, ...operation]) {
+    const resolved = resolveOas2Reference(
+      raw,
+      definitions,
+      PARAMETERS_REF_PREFIX
+    )
+    const parameter = liftOas2Parameter(resolved)
+    const key =
+      isPlainObject(parameter) &&
+      typeof parameter.in === "string" &&
+      typeof parameter.name === "string"
+        ? `${String(parameter.in)}:${String(parameter.name)}`
+        : `unkeyed:${unkeyedIndex++}`
+    merged.set(key, parameter)
+  }
+
+  return [...merged.values()]
+}
+
+function resolveOas2Reference(
+  value: unknown,
+  definitions: JsonObject,
+  prefix: string,
+  seen = new Set<string>()
+): unknown {
+  if (!isPlainObject(value) || typeof value.$ref !== "string") return value
+  if (!value.$ref.startsWith(prefix) || seen.has(value.$ref)) return value
+
+  const name = value.$ref.slice(prefix.length)
+  const resolved = definitions[name]
+  if (resolved === undefined) return value
+
+  seen.add(value.$ref)
+  const dereferenced = resolveOas2Reference(resolved, definitions, prefix, seen)
+  return isPlainObject(dereferenced) ? { ...dereferenced } : dereferenced
+}
+
+/**
+ * Lift Swagger 2.0 top-level type/enum/etc. onto `schema` for non-body params.
+ */
+function liftOas2Parameter(param: unknown): unknown {
+  if (
+    !isPlainObject(param) ||
+    param.$ref ||
+    param.in === "body" ||
+    param.schema
+  ) {
+    return param
+  }
+
+  const next: JsonObject = { ...param }
+  const schema: JsonObject = {}
+
+  for (const key of OAS2_SCHEMA_KEYS) {
+    if (next[key] !== undefined) {
+      schema[key] = next[key]
+      delete next[key]
+    }
+  }
+
+  // OAS2 file uploads → OAS3 binary string
+  if (schema.type === "file") {
+    schema.type = "string"
+    schema.format = "binary"
+  }
+
+  if (Object.keys(schema).length > 0) {
+    next.schema = schema
+  }
+
+  return next
+}
+
+function formDataToSchema(formParams: JsonObject[]): JsonObject {
+  const properties: JsonObject = {}
+  const required: string[] = []
+
+  for (const param of formParams) {
+    if (typeof param.name !== "string") continue
+    properties[param.name] = param.schema ?? { type: "string" }
+    if (param.required) required.push(param.name)
+  }
+
+  return {
+    type: "object",
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+  }
+}
+
+function rewriteDefinitionRefs(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(rewriteDefinitionRefs)
+  }
+  if (!isPlainObject(value)) return value
+
+  const result: JsonObject = {}
+  for (const [key, nested] of Object.entries(value)) {
+    if (
+      key === "$ref" &&
+      typeof nested === "string" &&
+      nested.startsWith(DEFINITIONS_REF_PREFIX)
+    ) {
+      result[key] =
+        COMPONENTS_SCHEMAS_REF_PREFIX +
+        nested.slice(DEFINITIONS_REF_PREFIX.length)
+    } else {
+      result[key] = rewriteDefinitionRefs(nested)
+    }
+  }
+  return result
+}
+
+function pickMediaType(types: string[]): string {
+  if (types.length === 0) return DEFAULT_MEDIA_TYPE
+  return types.find((t) => t.includes("json")) ?? types[0] ?? DEFAULT_MEDIA_TYPE
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const strings = value.filter((v): v is string => typeof v === "string")
+  return strings.length > 0 ? strings : undefined
+}
+
+function asObject(value: unknown): JsonObject {
+  return isPlainObject(value) ? value : {}
+}
+
+function ensureObject(parent: JsonObject, key: string): JsonObject {
+  const existing = parent[key]
+  if (isPlainObject(existing)) return existing
+  const created: JsonObject = {}
+  parent[key] = created
+  return created
+}
+
+function isPlainObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function isHttpMethod(method: string): boolean {
+  return HTTP_METHODS.has(method.toLowerCase())
+}

--- a/packages/zenko/src/zenko.ts
+++ b/packages/zenko/src/zenko.ts
@@ -3,6 +3,7 @@ import { formatPropertyName, isValidJSIdentifier } from "./utils/property-name"
 import { toCamelCase, capitalize } from "./utils/string-utils"
 import { analyzeZenkoUsage, generateZenkoImport } from "./utils/tree-shaking"
 import { collectReferencedSchemas } from "./utils/collect-referenced-schemas"
+import { normalizeSpecForSchemaVersion } from "./utils/normalize-oas2"
 import {
   type SchemaOptions,
   generateZodSchema,
@@ -23,11 +24,18 @@ import type {
 import { generateHelperFile } from "./utils/generate-helper-file"
 
 export type OpenAPISpec = {
-  openapi: string
+  openapi?: string
+  swagger?: string | number
   info: unknown
   paths: Record<string, Record<string, unknown>>
   webhooks?: Record<string, Record<string, unknown>>
   security?: Record<string, string[]>[]
+  consumes?: string[]
+  produces?: string[]
+  definitions?: Record<string, unknown>
+  parameters?: Record<string, unknown>
+  responses?: Record<string, unknown>
+  securityDefinitions?: Record<string, unknown>
   components?: {
     schemas?: Record<string, unknown>
     parameters?: Record<string, unknown>
@@ -51,6 +59,8 @@ export type EnumConfig = {
   unknownPrefix?: string
 }
 
+export type SchemaVersion = "oas3" | "oas2" | "auto"
+
 export type GenerateOptions = {
   strictDates?: boolean
   strictNumeric?: boolean
@@ -58,6 +68,11 @@ export type GenerateOptions = {
   types?: TypesConfig
   operationIds?: string[]
   openEnums?: boolean | string[] | EnumConfig
+  /**
+   * Spec dialect for parsing. `"auto"` (default) detects Swagger 2.0 via
+   * `swagger: "2.0"` and normalizes it to OpenAPI 3 shape before generation.
+   */
+  schemaVersion?: SchemaVersion
 }
 
 export type GenerateResult = {
@@ -107,6 +122,7 @@ export function generateWithMetadata(
     dateTimeOffset = true,
     operationIds,
     openEnums = false,
+    schemaVersion = "auto",
   } = options
   const typesConfig = normalizeTypesConfig({
     ...options.types,
@@ -121,6 +137,8 @@ export function generateWithMetadata(
     openEnums: enumConfig.open,
     openEnumPrefix: enumConfig.prefix,
   }
+
+  spec = normalizeSpecForSchemaVersion(spec, schemaVersion)
 
   output.push('import { z } from "zod";')
 

--- a/packages/zenko/zenko-config.schema.json
+++ b/packages/zenko/zenko-config.schema.json
@@ -137,6 +137,12 @@
             }
           ],
           "description": "Make enums 'open' to accept unknown string values. If true, all enums are open. If array, only named enums in the list are open. If object, use 'open' to specify which enums are open and 'unknownPrefix' to customize the prefix. Unknown values are transformed to template literals like `${prefix}${value}`."
+        },
+        "schemaVersion": {
+          "type": "string",
+          "enum": ["oas3", "oas2", "auto"],
+          "default": "auto",
+          "description": "OpenAPI dialect for this schema. 'auto' detects Swagger 2.0 via swagger: \"2.0\" and normalizes definitions/response schemas to OpenAPI 3 shape. 'oas2' forces Swagger 2.0 normalization. 'oas3' skips normalization."
         }
       }
     }


### PR DESCRIPTION
<!-- kanri-summary-start -->
## What this PR does

This PR adds Swagger 2.0 (OpenAPI 2.0) support to Zenko by normalizing v2 specs into an OpenAPI 3 shape before code generation. It introduces a `schemaVersion` option (`auto`/`oas2`/`oas3`) across the public API, CLI, and config schema, adds a dedicated normalization utility, and validates the behavior with a Blockscout Swagger 2.0 fixture and tests.
<!-- kanri-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generating schemas from Swagger 2.0 specifications, alongside OpenAPI 3.x.
  - Added the optional `schemaVersion` setting (`auto`, `oas2`, or `oas3`) to generation configurations.
  - Automatic version detection and conversion are enabled by default.
  - Added a Blockscout Stats service API specification and generated-schema example.

- **Tests**
  - Added coverage for version detection, Swagger-to-OpenAPI conversion, request/response handling, and Blockscout schema generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core spec ingestion and generation paths; incorrect normalization could change generated types for v2 APIs, though OAS3 specs are unchanged when `schemaVersion` is `auto` or `oas3`.
> 
> **Overview**
> Adds **Swagger 2.0 (OpenAPI v2)** support by normalizing specs to an OpenAPI 3-shaped document before the existing generator runs.
> 
> A new **`schemaVersion`** option (`auto` | `oas2` | `oas3`) is wired through **`generate`**, the **CLI**, and **`zenko-config.schema.json`**, and **`SchemaVersion`** is exported from the package. **`normalize-oas2`** handles definitions → `components.schemas`, response `schema` → `content`, body/formData parameters → `requestBody`, shared parameter/response `$ref`s, path-level parameters, and `#/definitions/` → `#/components/schemas/` refs.
> 
> **`OpenAPISpec`** is extended to accept v2 fields (`swagger`, `definitions`, `securityDefinitions`, etc.). Validation uses a **Blockscout Stats API** Swagger 2.0 fixture in `@zenko/specs`, with tests and examples codegen for `blockscout.gen.ts`. Examples also bump **axios** / **undici** and **zenko** to `0.3.0-beta.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ead7e48ae151fb3c60475342e9a7b55c4eb3952a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->